### PR TITLE
Improved output formatting for UserAccountControl flags

### DIFF
--- a/Scripts/script-ADGetUser.yml
+++ b/Scripts/script-ADGetUser.yml
@@ -90,8 +90,12 @@ script: |-
               if 'UserAccountControl' not in m['Contents'][0] or m['Contents'][0]['UserAccountControl'] == "":
                   continue
               if userAccountControlOut:
+                  accountControlFlags = ""
                   for flag, mask in UserAccountControlFlags.iteritems():
-                      m['Contents'][0][flag] = int(m['Contents'][0]['UserAccountControl'],10) & mask != 0
+                      if simulated_flag & mask != 0:
+                          accountControlFlags += flag + ", "
+                  accountControlFlags = accountControlFlags[:-2]
+                  m['Contents'][0]['UserAccountControl'] = accountControlFlags
               else:
                   m['Contents'][0]['ACCOUNTDISABLE'] = int(m['Contents'][0]['UserAccountControl'],10) & 2 != 0
           return resAD


### PR DESCRIPTION
Instead of creating a row for each possible flag and set true/false values, merge the flags that are actually set in one row.
See:
![image](https://user-images.githubusercontent.com/14124578/45736388-0c210780-bbeb-11e8-95cb-7763ff72f0d0.png)
instead of
![image](https://user-images.githubusercontent.com/14124578/45736421-2f4bb700-bbeb-11e8-94ae-26d38f98083c.png)

